### PR TITLE
[MRG] fix conda package caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,4 @@ install:
 
 script:
   - ./run_eelpond nema-download.yaml assemble
+  - rm -fr miniconda/env/test-env

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # eelpond
 
+[![Build Status](https://travis-ci.org/dib-lab/eelpond.svg?branch=master)](https://travis-ci.org/dib-lab/eelpond)
+
 ```
                            ___
                         .-'   `'.


### PR DESCRIPTION
This PR to the Travis CI config deletes the test-env conda environment before caching. Failing to do this means that it's deleted from the cache directory on install, which in turn seems to cause travis to re-generate the cache each time. This kinda defeats the purpose of caching.

An alternative would be to detect the existence of the environment and not rebuild it.

