### PR TITLE
[MRG] fix pear

### DIFF
--- a/rules/pear/pear-wrapper.py
+++ b/rules/pear/pear-wrapper.py
@@ -47,7 +47,7 @@ def move_files(in_list, out_list, gzip):
             shell('gzip -9 {f}')
     
 pval =  snakemake.params.get("pval", '.01')
-max_mem = snakemake.params.get('max_memory', "20G")
+max_mem = snakemake.params.get('max_memory', "4G")
 extra = snakemake.params.get('extra', "")
 
 shell("pear -f {r1} -r {r2} -p {pval} -j {snakemake.threads} -y {max_mem} {extra} -o {out_base} {log}")

--- a/rules/pear/pear.rule
+++ b/rules/pear/pear.rule
@@ -32,10 +32,10 @@ rule pear_read_merging:
         """--- Merging paired reads using PEAR  ---"""
     params:
         pval = pear_params.get('pval',"0.01"),
-        max_mem = pear_params.get('max_memory', "20G"),
+        max_memory = pear_params.get('max_memory', "4G"),
         extra = pear_params.get('extra', '')
     threads: 6
     log: join(LOGS_DIR, 'pear/{sample}_{unit}.log')
-    benchmark`: join(LOGS_DIR, 'pear/{sample}_{unit}.benchmark')
+    benchmark: join(LOGS_DIR, 'pear/{sample}_{unit}.benchmark')
     conda: 'pear-env.yaml'
     script: 'pear-wrapper.py'


### PR DESCRIPTION
Pear `max_memory` parameter was not getting passed to the `pear-wrapper.py` properly, and the default value was too high.

Also fixes a typo in the `benchmark` part of the pear rule.

Closes  #53 