### PR TITLE
[MRG] Better dag handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - source activate test-env
 
 script:
+  - pytest -v
   - ./run_eelpond examples/nema.yaml get_data -t 4 --restart_times=3
   - ./run_eelpond examples/nema.yaml assemble -t 4
   - rm -fr $HOME/miniconda/envs/test-env $HOME/miniconda/pkgs/cache

--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - networkx
   - pygraphviz
   - psutil
+  - pytest

--- a/ep_utils/capture_stdout.py
+++ b/ep_utils/capture_stdout.py
@@ -1,0 +1,50 @@
+from io import StringIO
+import sys
+
+
+class CaptureStdout(list):
+    """
+    A utility object that uses a context manager
+    to capture stdout from Snakemake. Useful when
+    creating the directed acyclic graph.
+    """
+    def __init__(self,passthru=False):
+        # Boolean: should we pass everything through to stdout?
+        # (this object is only functional if passthru is False)
+        self.passthru = passthru
+
+    def __enter__(self):
+        # Open a new context with this CaptureStdout
+        # object. This happens when we say
+        # "with CatpureStdout('label') as output:"
+
+        # If we are just passing input on to output, pass thru
+        if self.passthru:
+            return self
+
+        # Otherwise, we want to swap out sys.stdout with
+        # a StringIO object that will save stdout.
+        # 
+        # Save the existing stdout object so we can
+        # restore it when we're done
+        self._stdout = sys.stdout
+        # Now swap out stdout 
+        sys.stdout = self._stringio = StringIO()
+        return self
+
+    def __exit__(self, *args):
+        # If we are just passing input on to output, pass thru
+        if self.passthru:
+            return self
+
+        # This entire class extends the list class,
+        # so we call self.extend() to add a list to 
+        # the end of self (in this case, all the new
+        # lines from our StringIO object).
+        self.extend(self._stringio.getvalue().splitlines())
+        del self._stringio    # free up some memory
+
+        # Clean up by setting sys.stdout back to what
+        # it was before we opened up this context.
+        sys.stdout = self._stdout
+

--- a/run_eelpond
+++ b/run_eelpond
@@ -12,10 +12,13 @@ import yaml
 import glob
 import collections
 import snakemake
+import shutil
+import subprocess
 
 from ep_utils.utils import *
 from ep_utils.pretty_config import pretty_name, write_config
 from ep_utils.print_workflow_options import print_available_workflows_and_tools
+from ep_utils.capture_stdout import CaptureStdout
 
 def build_default_params(workdir, targets):
     defaultParams = {}
@@ -137,8 +140,24 @@ def main(args):
         write_config(default_params, targs)
         sys.exit(0)
     
+    # are we building a directed acyclic graph?
+    building_dag = False
+    if args.dag or args.dagfile or args.dagpng:
+
+        building_dag = True
+
+        # building dags precludes running any workflows
+        args.dry_run = True
+
+        # if user specified --dagpng,
+        # graphviz dot must be present
+        if args.dagpng:
+            if shutil.which('dot') is None:
+                sys.stderr.write(f"\n\tError: Cannot find 'dot' utility, but --dotpng flag was specified. Fix this by installing graphviz dot.\n\n")
+                sys.exit(-1)
+
     # first, find the Snakefile and configfile
-    if not args.dag:
+    if not building_dag:
         print('\n--------')
         print('checking for required files:')
         print('--------\n')
@@ -204,7 +223,7 @@ def main(args):
             else:
                 reportfile = os.path.abspath(os.path.join(paramsD['eelpond_directories']['logs'], args.report))
 
-        if not args.dag:
+        if not building_dag:
             print('--------')
             print('details!')
             print('\tsnakefile: {}'.format(snakefile))
@@ -214,29 +233,63 @@ def main(args):
             print('\treport: {}'.format(repr(reportfile)))
             print('--------')
 
-        # run!!
-        # params file becomes snakemake configfile
-        status = snakemake.snakemake(snakefile, configfile=paramsfile, use_conda=True, 
-                                 targets=['eelpond'], printshellcmds=True, 
-                                 cores=args.threads, cleanup_conda= args.cleanup_conda,
-                                 dryrun=args.dry_run, lock=not args.nolock,
-                                 unlock=args.unlock,
-                                 verbose=args.verbose, debug_dag=args.debug, 
-                                 conda_prefix=args.conda_prefix, 
-                                 create_envs_only=args.create_envs_only,
-                                 restart_times=args.restart_times,
-                                 printdag=args.dag, keepgoing=args.keep_going,
-                                 forcetargets=args.forcetargets,forceall=args.forceall)
-    
-        if status and reportfile and not args.dry_run and not args.unlock and not args.dag:
+
+        # Set up a context manager to capture stdout if we're building
+        # a directed acyclic graph (which prints the graph in dot format
+        # to stdout instead of to a file).
+        # If we are not bulding a dag, pass all output straight to stdout
+        # without capturing any of it.
+        passthru = not building_dag
+        with CaptureStdout(passthru=passthru) as output:
+            # run!!
+            # params file becomes snakemake configfile
+            status = snakemake.snakemake(snakefile, configfile=paramsfile, use_conda=True, 
+                                     targets=['eelpond'], printshellcmds=True, 
+                                     cores=args.threads, cleanup_conda= args.cleanup_conda,
+                                     dryrun=args.dry_run, lock=not args.nolock,
+                                     unlock=args.unlock,
+                                     verbose=args.verbose, debug_dag=args.debug, 
+                                     conda_prefix=args.conda_prefix, 
+                                     create_envs_only=args.create_envs_only,
+                                     restart_times=args.restart_times,
+                                     printdag=building_dag, keepgoing=args.keep_going,
+                                     forcetargets=args.forcetargets,forceall=args.forceall)
+
+        if building_dag:
+
+            # These three --build args are mutually exclusive,
+            # and are checked in order of precedence (hi to low):
+            # --dag         to stdout
+            # --dagfile     to .dot
+            # --dagpng      to .png
+
+            if args.dag:
+                # straight to stdout
+                print("\n".join(output))
+
+            elif args.dagfile:
+                with open(args.dagfile,'w') as f:
+                    f.write("\n".join(output))
+                print(f"\tPrinted workflow dag to dot file {args.dagfile}\n\n ")
+
+            elif args.dagpng:
+                # dump dot output to temporary dot file
+                with open('.temp.dot','w') as f:
+                    f.write("\n".join(output))
+                subprocess.call(['dot','-Tpng','.temp.dot','-o',args.dagpng])
+                subprocess.call(['rm','-f','.temp.dot'])
+                print(f"\tPrinted workflow dag to png file {args.dagpng}\n\n ")
+
+        if status and reportfile and not args.dry_run and not args.unlock and not building_dag:
             snakemake.snakemake(snakefile, configfile=paramsfile, report=reportfile)
             print(f"\t see the report file at {reportfile}\n\n ")
+
         if status: # translate "success" into shell exit code of 0
            return 0
         return 1
 
 
-# TODO: would be good to pull availble rules from eelpond_pipeline in default config or a separate workflow file!
+# TODO: would be good to pull available rules from eelpond_pipeline in default config or a separate workflow file!
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='run snakemake eelpond', usage='''run_eelpond <configfile.yaml>  [<target> ...]
 
@@ -280,7 +333,9 @@ To build an editable configfile to start work on your own data, run:
     parser.add_argument('--conda_prefix', default=None, help='location for conda environment installs')
     parser.add_argument('--create_envs_only', action='store_true', help="just install software in conda envs, don't execute workflows")
     parser.add_argument('-d', '--debug', action='store_true')
-    parser.add_argument('--dag', action='store_true')
+    parser.add_argument('--dag', action='store_true', help='boolean: output a flowchart of the directed acyclic graph of this workflow in graphviz dot format (does not require/run dot)')
+    parser.add_argument('--dagfile', default=None, help='filename to output a flowchart of the directed acyclic graph of this workflow in graphviz dot format')
+    parser.add_argument('--dagpng',  default=None, help='filename to output a flowchart of the directed acyclic graph of this workflow in png image format')
     parser.add_argument('-k', '--keep_going', action='store_true')
     parser.add_argument('--nolock', action='store_true')
     parser.add_argument('--unlock', action='store_true')

--- a/run_eelpond
+++ b/run_eelpond
@@ -226,7 +226,7 @@ def main(args):
                                  printdag=args.dag, keepgoing=args.keep_going,
                                  forcetargets=args.forcetargets,forceall=args.forceall)
     
-        if status and reportfile and not args.dry_run and not args.unlock:
+        if status and reportfile and not args.dry_run and not args.unlock and not args.dag:
             snakemake.snakemake(snakefile, configfile=paramsfile, report=reportfile)
             print(f"\t see the report file at {reportfile}\n\n ")
         if status: # translate "success" into shell exit code of 0

--- a/run_eelpond
+++ b/run_eelpond
@@ -138,9 +138,10 @@ def main(args):
         sys.exit(0)
     
     # first, find the Snakefile and configfile
-    print('\n--------')
-    print('checking for required files:')
-    print('--------\n')
+    if not args.dag:
+        print('\n--------')
+        print('checking for required files:')
+        print('--------\n')
     
     snakefile = find_Snakefile(thisdir)
     
@@ -203,14 +204,15 @@ def main(args):
             else:
                 reportfile = os.path.abspath(os.path.join(paramsD['eelpond_directories']['logs'], args.report))
 
-        print('--------')
-        print('details!')
-        print('\tsnakefile: {}'.format(snakefile))
-        print('\tconfig: {}'.format(configfile))
-        print('\tparams: {}'.format(paramsfile))
-        print('\ttargets: {}'.format(repr(targs)))
-        print('\treport: {}'.format(repr(reportfile)))
-        print('--------')
+        if not args.dag:
+            print('--------')
+            print('details!')
+            print('\tsnakefile: {}'.format(snakefile))
+            print('\tconfig: {}'.format(configfile))
+            print('\tparams: {}'.format(paramsfile))
+            print('\ttargets: {}'.format(repr(targs)))
+            print('\treport: {}'.format(repr(reportfile)))
+            print('--------')
 
         # run!!
         # params file becomes snakemake configfile

--- a/tests/Readme.md
+++ b/tests/Readme.md
@@ -1,0 +1,42 @@
+# eelpond tests
+
+This directory contains tests for eelpond.
+
+The test strategy is as follows:
+
+* Use the `unittest` library to write unit tests
+* Use the `subprocess` library to run eelpond workflows from the command line
+* Capture the output of each `subprocess` command and make assertions about its contents
+
+To run all tests, use the `pytest` command to automatically search for and run all
+tests. This command can be run either from this `tests/` directory or from the top level
+of the repository: 
+
+```
+pytest -v
+```
+
+If all goes well, you should see output like this:
+
+```
+$ pytest -v
+=============================================== test session starts ================================================
+platform darwin -- Python 3.6.3, pytest-4.2.0, py-1.7.0, pluggy-0.8.1 -- /Users/charles/.pyenv/versions/miniconda3-4.3.30/bin/python
+cachedir: .pytest_cache
+rootdir: /temp/eelpond/tests, inifile:
+collected 10 items
+
+test_config.py::TestConfig::test_build_config PASSED                                                         [ 10%]
+test_config.py::TestConfig::test_extra_config PASSED                                                         [ 20%]
+test_dag.py::TestDag::test_dag_flag PASSED                                                                   [ 30%]
+test_dag.py::TestDag::test_dagfile_flag PASSED                                                               [ 40%]
+test_dag.py::TestDag::test_dagpng_flag PASSED                                                                [ 50%]
+test_flags.py::TestFlags::test_dry_run_flag PASSED                                                           [ 60%]
+test_flags.py::TestFlags::test_help_flag PASSED                                                              [ 70%]
+test_print.py::TestPrint::test_print_params PASSED                                                           [ 80%]
+test_print.py::TestPrint::test_print_rules PASSED                                                            [ 90%]
+test_print.py::TestPrint::test_print_workflows PASSED                                                        [100%]
+
+============================================ 10 passed in 12.61 seconds ============================================
+```
+

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,0 +1,8 @@
+import os
+
+here = os.path.dirname(os.path.abspath(__file__))
+
+run_eelpond_cmd = os.path.join(here,'..','run_eelpond')
+
+test_config_yaml = os.path.join(here,'test_config.yaml')
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+from unittest import TestCase
+from .const import (here, run_eelpond_cmd, test_config_yaml)
+from .utils import capture_stdouterr
+
+
+class TestConfig(TestCase):
+    """
+    This class runs tests of eelpond config utilities:
+    --build_config
+    --extra-config
+    """
+    def test_build_config(self):
+        """Test the --build_config flag"""
+        command = [run_eelpond_cmd, '--build_config']
+        p_out, p_err = capture_stdouterr(command,here)
+        pass
+
+    def test_extra_config(self):
+        """Test the --build_config flag"""
+        command = [run_eelpond_cmd, '-n', '--extra_config']
+        p_out, p_err = capture_stdouterr(command,here)
+        pass
+
+

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,0 +1,12 @@
+# nema: a non-random subset of data from Tulin et al. (2013), that can
+# be used to do assembly and comparative expression analysis.
+
+# this sets the output directory name:
+basename: 'nema'
+
+# this describes the samples:
+samples: "../examples/nema.samples.tsv"
+
+# this says to download samples specified as Web URLs:
+get_data:
+  download_data: True

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,0 +1,76 @@
+from unittest import TestCase
+from .const import (here, run_eelpond_cmd, test_config_yaml)
+from .utils import capture_stdouterr
+import subprocess
+import os
+
+
+class TestDag(TestCase):
+    """
+    This class runs tests of eelpond dag flags and functionality:
+    --dag
+    --dagfile
+    --dagpng
+    """
+    def test_dag_flag(self):
+        which_workflow = 'default'
+        flags = '--dag'
+        command = [run_eelpond_cmd, test_config_yaml, which_workflow, flags]
+        p_out, p_err = capture_stdouterr(command,here)
+
+        # Look for this message in snakemake output
+        self.assertIn('Building DAG of jobs...',p_err)
+
+        # Verify some Graphviz notation showed up
+        self.assertIn('digraph',p_out)
+        self.assertIn('node',p_out)
+        self.assertIn('edge',p_out)
+
+    def test_dagfile_flag(self):
+        """Test the --dagfile=<dotfile> flag
+        """
+        dotfile_name = 'dag.dot'
+        dotfile_fullpath = os.path.join(here,dotfile_name)
+        which_workflow = 'default'
+        flags = '--dagfile=%s'%(dotfile_fullpath)
+        command = [run_eelpond_cmd, test_config_yaml, which_workflow, flags]
+        p_out, p_err = capture_stdouterr(command,here)
+
+        # Look for this message in snakemake output
+        self.assertIn('Building DAG of jobs...',p_err)
+
+        # Output should print where dotfile went
+        self.assertIn('Printed workflow dag to dot file',p_out)
+        self.assertIn(dotfile_fullpath, p_out)
+
+        # The dotfile should now be a file on disk
+        self.assertTrue(os.path.exists(dotfile_fullpath))
+        self.assertTrue(os.path.isfile(dotfile_fullpath))
+
+        # Clean up
+        subprocess.call(['rm','-f',dotfile_fullpath])
+
+    def test_dagpng_flag(self):
+        """Test the --dagpng=<pngfile> flag
+        """
+        pngfile_name = 'dag.png'
+        pngfile_fullpath = os.path.join(here,pngfile_name)
+        which_workflow = 'default'
+        flags = '--dagpng=%s'%(pngfile_fullpath)
+        command = [run_eelpond_cmd, test_config_yaml, which_workflow, flags]
+        p_out, p_err = capture_stdouterr(command,here)
+
+        # Look for this message in snakemake output
+        self.assertIn('Building DAG of jobs...',p_err)
+
+        # Output should print where pngfile went
+        self.assertIn('Printed workflow dag to png file',p_out)
+        self.assertIn(pngfile_fullpath, p_out)
+
+        # The pngfile should now be a file on disk
+        self.assertTrue(os.path.exists(pngfile_fullpath))
+        self.assertTrue(os.path.isfile(pngfile_fullpath))
+
+        # Clean up
+        subprocess.call(['rm','-f',pngfile_fullpath])
+

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+from unittest import TestCase
+from .const import (here, run_eelpond_cmd, test_config_yaml)
+from .utils import capture_stdouterr
+
+
+class TestFlags(TestCase):
+    """
+    This class runs tests of eelpond with basic flags:
+    -h --help
+    -n --dry-run
+    """
+    @classmethod
+    def setUpClass(self):
+        """Set up a flags test"""
+        pass
+
+    def test_help_flag(self):
+        """Test the -h --help flag"""
+        command = [run_eelpond_cmd,'-h']
+        p_out, p_err = capture_stdouterr(command,here)
+        self.assertIn('eelpond',p_out)
+        self.assertIn('snakemake',p_out)
+
+    def test_dry_run_flag(self):
+        """Test the -n --dry-run flag"""
+        which_workflow = 'default'
+        flags = '-n'
+        command = [run_eelpond_cmd, test_config_yaml, which_workflow, flags]
+        p_out, p_err = capture_stdouterr(command,here)
+        verify_present = '''
+Job counts:
+	count	jobs
+	1	dammit_annotate
+	1	eelpond
+	20	fastqc_pretrim
+	20	fastqc_trimmed
+	10	http_get_fq1
+	10	http_get_fq2
+	10	khmer_pe_diginorm
+	10	khmer_split_paired
+	1	rename_trinity_fasta
+	1	salmon_index
+	2	salmon_quant_combine_units
+	1	sourmash_compute_assembly
+	10	sourmash_compute_pe_interleaved
+	10	trimmomatic_pe
+	1	trinity
+	108'''
+        # Skip the first element b/c empty line
+        for line in verify_present.split("\n")[1:]:
+            self.assertIn(line,p_out)
+
+        # Check that job descriptions are printed as they are
+        # added to the list of dry run tasks
+        verify_jobs = '''
+--- Quality trimming PE read data with Trimmomatic. ---
+--- khmer trimming of low-abundance kmers and digital normalization ---
+--- Computing a MinHash signature of the kmer-trimmed reads with Sourmash ---
+--- Assembling read data with Trinity --- 
+--- Indexing the transcriptome with Salmon ---'''
+        # Skip the first element b/c empty line
+        for line in verify_jobs.split("\n")[1:]:
+            self.assertIn(line,p_out)
+
+    @classmethod
+    def tearDownClass(self):
+        """Tear down after a test"""
+        pass
+

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+from unittest import TestCase
+from .const import (here, run_eelpond_cmd, test_config_yaml)
+from .utils import capture_stdouterr
+
+
+class TestPrint(TestCase):
+    """
+    This class runs tests of eelpond print functionality:
+    -w --print_workflows
+    -r --print_rules
+    -p --print_params
+    """
+    def test_print_workflows(self):
+        """Test the --print_workflows flag"""
+        command = [run_eelpond_cmd, '--print-workflows']
+        p_out, p_err = capture_stdouterr(command,here)
+
+        gold_output = '''
+  ####################  Available Eelpond Workflows  ####################
+
+
+  default:
+	get_data
+	trimmomatic
+	khmer
+	trinity
+	fastqc
+	dammit
+	salmon
+	sourmash
+
+  protein_assembly:
+	get_data
+	trimmomatic
+	khmer
+	plass
+	pear
+	fastqc
+	paladin
+	sourmash
+
+  input_data:
+	get_data
+
+  preprocess:
+	get_data
+	fastqc
+	trimmomatic
+
+  kmer_trim:
+	get_data
+	trimmomatic
+	khmer
+
+  assemble:
+	get_data
+	trimmomatic
+	khmer
+	trinity
+
+  assemblyinput:
+	assemblyinput
+
+  annotate:
+	dammit
+
+  quantify:
+	get_data
+	trimmomatic
+	salmon
+
+  diffexp:
+	get_data
+	trimmomatic
+	salmon
+	deseq2
+
+  sourmash_compute:
+	get_data
+	trimmomatic
+	khmer
+	sourmash
+
+  plass_assemble:
+	get_data
+	trimmomatic
+	khmer
+	plass
+
+  paladin_map:
+	get_data
+	trimmomatic
+	khmer
+	plass
+	pear
+	paladin
+
+  correct_reads:
+	get_data
+	trimmomatic
+	rcorrector'''
+
+        #self.assertIn(gold_output,p_out)
+        #self.assertIn(gold_output,p_err)
+        pass
+
+    def test_print_rules(self):
+        """Test the --print_rules flag"""
+        command = [run_eelpond_cmd, '--print-rules']
+        p_out, p_err = capture_stdouterr(command,here)
+        pass
+
+    def test_print_params(self):
+        """Test the --print_params flag"""
+        command = [run_eelpond_cmd, '--print-params']
+        p_out, p_err = capture_stdouterr(command,here)
+        pass
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,9 @@
+from .const import here
+from subprocess import Popen, PIPE
+
+def capture_stdouterr(command, cwd = here):
+    p = Popen(command, cwd=cwd, stdout=PIPE, stderr=PIPE).communicate()
+    p_out = p[0].decode('utf-8').strip()
+    p_err = p[1].decode('utf-8').strip()
+    return (p_out, p_err)
+


### PR DESCRIPTION
Don't print to stdout if building a `dag`. This change means that we can redirect the output directly to a dot file, or use graphviz to get an image (rather than needing to delete the extra lines first).

`./run_eelpond examples/nema.yaml default --dag > dagfile.dot`

or 

`./run_eelpond examples/nema.yaml default --dag | dot -Tpng > dagfile.png`

addresses #11 - provides all the functionality, though it doesn't enable an easy `--dagfile FILENAME` flag. Thoughts @charlesreid1?

