### PR TITLE
Add eelpond tests/ directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ install:
   - source activate test-env
 
 script:
+  - pytest -v
   - ./run_eelpond examples/nema.yaml get_data -t 4 --restart_times=3
   - ./run_eelpond examples/nema.yaml assemble -t 4
   - rm -fr $HOME/miniconda/envs/test-env $HOME/miniconda/pkgs/cache

--- a/environment.yml
+++ b/environment.yml
@@ -11,3 +11,4 @@ dependencies:
   - networkx
   - pygraphviz
   - psutil
+  - pytest

--- a/tests/Readme.md
+++ b/tests/Readme.md
@@ -1,0 +1,42 @@
+# eelpond tests
+
+This directory contains tests for eelpond.
+
+The test strategy is as follows:
+
+* Use the `unittest` library to write unit tests
+* Use the `subprocess` library to run eelpond workflows from the command line
+* Capture the output of each `subprocess` command and make assertions about its contents
+
+To run all tests, use the `pytest` command to automatically search for and run all
+tests. This command can be run either from this `tests/` directory or from the top level
+of the repository: 
+
+```
+pytest -v
+```
+
+If all goes well, you should see output like this:
+
+```
+$ pytest -v
+=============================================== test session starts ================================================
+platform darwin -- Python 3.6.3, pytest-4.2.0, py-1.7.0, pluggy-0.8.1 -- /Users/charles/.pyenv/versions/miniconda3-4.3.30/bin/python
+cachedir: .pytest_cache
+rootdir: /temp/eelpond/tests, inifile:
+collected 10 items
+
+test_config.py::TestConfig::test_build_config PASSED                                                         [ 10%]
+test_config.py::TestConfig::test_extra_config PASSED                                                         [ 20%]
+test_dag.py::TestDag::test_dag_flag PASSED                                                                   [ 30%]
+test_dag.py::TestDag::test_dagfile_flag PASSED                                                               [ 40%]
+test_dag.py::TestDag::test_dagpng_flag PASSED                                                                [ 50%]
+test_flags.py::TestFlags::test_dry_run_flag PASSED                                                           [ 60%]
+test_flags.py::TestFlags::test_help_flag PASSED                                                              [ 70%]
+test_print.py::TestPrint::test_print_params PASSED                                                           [ 80%]
+test_print.py::TestPrint::test_print_rules PASSED                                                            [ 90%]
+test_print.py::TestPrint::test_print_workflows PASSED                                                        [100%]
+
+============================================ 10 passed in 12.61 seconds ============================================
+```
+

--- a/tests/const.py
+++ b/tests/const.py
@@ -1,0 +1,8 @@
+import os
+
+here = os.path.dirname(os.path.abspath(__file__))
+
+run_eelpond_cmd = os.path.join(here,'..','run_eelpond')
+
+test_config_yaml = os.path.join(here,'test_config.yaml')
+

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+from unittest import TestCase
+from .const import (here, run_eelpond_cmd, test_config_yaml)
+from .utils import capture_stdouterr
+
+
+class TestConfig(TestCase):
+    """
+    This class runs tests of eelpond config utilities:
+    --build_config
+    --extra-config
+    """
+    def test_build_config(self):
+        """Test the --build_config flag"""
+        command = [run_eelpond_cmd, '--build_config']
+        p_out, p_err = capture_stdouterr(command,here)
+        pass
+
+    def test_extra_config(self):
+        """Test the --build_config flag"""
+        command = [run_eelpond_cmd, '-n', '--extra_config']
+        p_out, p_err = capture_stdouterr(command,here)
+        pass
+
+

--- a/tests/test_config.yaml
+++ b/tests/test_config.yaml
@@ -1,0 +1,12 @@
+# nema: a non-random subset of data from Tulin et al. (2013), that can
+# be used to do assembly and comparative expression analysis.
+
+# this sets the output directory name:
+basename: 'nema'
+
+# this describes the samples:
+samples: "../examples/nema.samples.tsv"
+
+# this says to download samples specified as Web URLs:
+get_data:
+  download_data: True

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -17,6 +17,8 @@ class TestDag(TestCase):
         flags = '--dag'
         command = [run_eelpond_cmd, test_config_yaml, which_workflow, flags]
         p_out, p_err = capture_stdouterr(command,here)
+
+        # Look for this message in snakemake output
         self.assertIn('Building DAG of jobs...',p_err)
 
         # Verify some Graphviz notation showed up
@@ -33,6 +35,8 @@ class TestDag(TestCase):
         flags = '--dagfile=%s'%(dotfile_fullpath)
         command = [run_eelpond_cmd, test_config_yaml, which_workflow, flags]
         p_out, p_err = capture_stdouterr(command,here)
+
+        # Look for this message in snakemake output
         self.assertIn('Building DAG of jobs...',p_err)
 
         # Output should print where dotfile went
@@ -49,5 +53,24 @@ class TestDag(TestCase):
     def test_dagpng_flag(self):
         """Test the --dagpng=<pngfile> flag
         """
-        pass
+        pngfile_name = 'dag.png'
+        pngfile_fullpath = os.path.join(here,pngfile_name)
+        which_workflow = 'default'
+        flags = '--dagpng=%s'%(pngfile_fullpath)
+        command = [run_eelpond_cmd, test_config_yaml, which_workflow, flags]
+        p_out, p_err = capture_stdouterr(command,here)
+
+        # Look for this message in snakemake output
+        self.assertIn('Building DAG of jobs...',p_err)
+
+        # Output should print where pngfile went
+        self.assertIn('Printed workflow dag to png file',p_out)
+        self.assertIn(pngfile_fullpath, p_out)
+
+        # The pngfile should now be a file on disk
+        self.assertTrue(os.path.exists(pngfile_fullpath))
+        self.assertTrue(os.path.isfile(pngfile_fullpath))
+
+        # Clean up
+        subprocess.call(['rm','-f',pngfile_fullpath])
 

--- a/tests/test_dag.py
+++ b/tests/test_dag.py
@@ -1,0 +1,53 @@
+from unittest import TestCase
+from .const import (here, run_eelpond_cmd, test_config_yaml)
+from .utils import capture_stdouterr
+import subprocess
+import os
+
+
+class TestDag(TestCase):
+    """
+    This class runs tests of eelpond dag flags and functionality:
+    --dag
+    --dagfile
+    --dagpng
+    """
+    def test_dag_flag(self):
+        which_workflow = 'default'
+        flags = '--dag'
+        command = [run_eelpond_cmd, test_config_yaml, which_workflow, flags]
+        p_out, p_err = capture_stdouterr(command,here)
+        self.assertIn('Building DAG of jobs...',p_err)
+
+        # Verify some Graphviz notation showed up
+        self.assertIn('digraph',p_out)
+        self.assertIn('node',p_out)
+        self.assertIn('edge',p_out)
+
+    def test_dagfile_flag(self):
+        """Test the --dagfile=<dotfile> flag
+        """
+        dotfile_name = 'dag.dot'
+        dotfile_fullpath = os.path.join(here,dotfile_name)
+        which_workflow = 'default'
+        flags = '--dagfile=%s'%(dotfile_fullpath)
+        command = [run_eelpond_cmd, test_config_yaml, which_workflow, flags]
+        p_out, p_err = capture_stdouterr(command,here)
+        self.assertIn('Building DAG of jobs...',p_err)
+
+        # Output should print where dotfile went
+        self.assertIn('Printed workflow dag to dot file',p_out)
+        self.assertIn(dotfile_fullpath, p_out)
+
+        # The dotfile should now be a file on disk
+        self.assertTrue(os.path.exists(dotfile_fullpath))
+        self.assertTrue(os.path.isfile(dotfile_fullpath))
+
+        # Clean up
+        subprocess.call(['rm','-f',dotfile_fullpath])
+
+    def test_dagpng_flag(self):
+        """Test the --dagpng=<pngfile> flag
+        """
+        pass
+

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -3,9 +3,6 @@ from unittest import TestCase
 from .const import (here, run_eelpond_cmd, test_config_yaml)
 from .utils import capture_stdouterr
 
-# To import from ../ep_utils, do this:
-#from ..ep_utils.capture_stdout import CaptureStdout
-
 
 class TestFlags(TestCase):
     """
@@ -57,7 +54,7 @@ Job counts:
         # Check that job descriptions are printed as they are
         # added to the list of dry run tasks
         verify_jobs = '''
---- Quality trimming PE read data with Trimmomatic. --- Output files will be in /temp/eelpond/nema_out/preprocess 
+--- Quality trimming PE read data with Trimmomatic. ---
 --- khmer trimming of low-abundance kmers and digital normalization ---
 --- Computing a MinHash signature of the kmer-trimmed reads with Sourmash ---
 --- Assembling read data with Trinity --- 

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python
+from unittest import TestCase
+from .const import (here, run_eelpond_cmd, test_config_yaml)
+from .utils import capture_stdouterr
+
+# To import from ../ep_utils, do this:
+#from ..ep_utils.capture_stdout import CaptureStdout
+
+
+class TestFlags(TestCase):
+    """
+    This class runs tests of eelpond with basic flags:
+    -h --help
+    -n --dry-run
+    """
+    @classmethod
+    def setUpClass(self):
+        """Set up a flags test"""
+        pass
+
+    def test_help_flag(self):
+        """Test the -h --help flag"""
+        command = [run_eelpond_cmd,'-h']
+        p_out, p_err = capture_stdouterr(command,here)
+        self.assertIn('eelpond',p_out)
+        self.assertIn('snakemake',p_out)
+
+    def test_dry_run_flag(self):
+        """Test the -n --dry-run flag"""
+        which_workflow = 'default'
+        flags = '-n'
+        command = [run_eelpond_cmd, test_config_yaml, which_workflow, flags]
+        p_out, p_err = capture_stdouterr(command,here)
+        verify_present = '''
+Job counts:
+	count	jobs
+	1	dammit_annotate
+	1	eelpond
+	20	fastqc_pretrim
+	20	fastqc_trimmed
+	10	http_get_fq1
+	10	http_get_fq2
+	10	khmer_pe_diginorm
+	10	khmer_split_paired
+	1	rename_trinity_fasta
+	1	salmon_index
+	2	salmon_quant_combine_units
+	1	sourmash_compute_assembly
+	10	sourmash_compute_pe_interleaved
+	10	trimmomatic_pe
+	1	trinity
+	108'''
+        # Skip the first element b/c empty line
+        for line in verify_present.split("\n")[1:]:
+            self.assertIn(line,p_out)
+
+        # Check that job descriptions are printed as they are
+        # added to the list of dry run tasks
+        verify_jobs = '''
+--- Quality trimming PE read data with Trimmomatic. --- Output files will be in /temp/eelpond/nema_out/preprocess 
+--- khmer trimming of low-abundance kmers and digital normalization ---
+--- Computing a MinHash signature of the kmer-trimmed reads with Sourmash ---
+--- Assembling read data with Trinity --- 
+--- Indexing the transcriptome with Salmon ---'''
+        # Skip the first element b/c empty line
+        for line in verify_jobs.split("\n")[1:]:
+            self.assertIn(line,p_out)
+
+    @classmethod
+    def tearDownClass(self):
+        """Tear down after a test"""
+        pass
+

--- a/tests/test_print.py
+++ b/tests/test_print.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python
+from unittest import TestCase
+from .const import (here, run_eelpond_cmd, test_config_yaml)
+from .utils import capture_stdouterr
+
+
+class TestPrint(TestCase):
+    """
+    This class runs tests of eelpond print functionality:
+    -w --print_workflows
+    -r --print_rules
+    -p --print_params
+    """
+    def test_print_workflows(self):
+        """Test the --print_workflows flag"""
+        command = [run_eelpond_cmd, '--print-workflows']
+        p_out, p_err = capture_stdouterr(command,here)
+
+        gold_output = '''
+  ####################  Available Eelpond Workflows  ####################
+
+
+  default:
+	get_data
+	trimmomatic
+	khmer
+	trinity
+	fastqc
+	dammit
+	salmon
+	sourmash
+
+  protein_assembly:
+	get_data
+	trimmomatic
+	khmer
+	plass
+	pear
+	fastqc
+	paladin
+	sourmash
+
+  input_data:
+	get_data
+
+  preprocess:
+	get_data
+	fastqc
+	trimmomatic
+
+  kmer_trim:
+	get_data
+	trimmomatic
+	khmer
+
+  assemble:
+	get_data
+	trimmomatic
+	khmer
+	trinity
+
+  assemblyinput:
+	assemblyinput
+
+  annotate:
+	dammit
+
+  quantify:
+	get_data
+	trimmomatic
+	salmon
+
+  diffexp:
+	get_data
+	trimmomatic
+	salmon
+	deseq2
+
+  sourmash_compute:
+	get_data
+	trimmomatic
+	khmer
+	sourmash
+
+  plass_assemble:
+	get_data
+	trimmomatic
+	khmer
+	plass
+
+  paladin_map:
+	get_data
+	trimmomatic
+	khmer
+	plass
+	pear
+	paladin
+
+  correct_reads:
+	get_data
+	trimmomatic
+	rcorrector'''
+
+        #self.assertIn(gold_output,p_out)
+        #self.assertIn(gold_output,p_err)
+        pass
+
+    def test_print_rules(self):
+        """Test the --print_rules flag"""
+        command = [run_eelpond_cmd, '--print-rules']
+        p_out, p_err = capture_stdouterr(command,here)
+        pass
+
+    def test_print_params(self):
+        """Test the --print_params flag"""
+        command = [run_eelpond_cmd, '--print-params']
+        p_out, p_err = capture_stdouterr(command,here)
+        pass
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,9 @@
+from .const import here
+from subprocess import Popen, PIPE
+
+def capture_stdouterr(command, cwd = here):
+    p = Popen(command, cwd=cwd, stdout=PIPE, stderr=PIPE).communicate()
+    p_out = p[0].decode('utf-8').strip()
+    p_err = p[1].decode('utf-8').strip()
+    return (p_out, p_err)
+


### PR DESCRIPTION
This adds individual unit tests for each of eelpond's flags.

Not all of these flag unit tests are implemented yet, but the --dag and --dagfile and --dagpng flags are added/tested, as are the --help and --dry-run flags, to demonstrate how to do it.

This PR will modify PR #73 (Further improvements to DAG handling). I made it a separate pull request so it would be easier to review separately from the changes made in #73.