### PR TITLE
[MRG] override deseq2 default contrasts

### DIFF
--- a/run_eelpond
+++ b/run_eelpond
@@ -205,8 +205,14 @@ def main(args):
         # rather than doing this when reading in the main configfile
         
         # if we're adding any additional contrasts, get rid of the example ones!
-        if extra_configs.get('deseq2') or configD.get('deseq2'):
-            if paramsD.get('deseq2'):
+        # check extra configs
+        if extra_configs.get('deseq2'):
+           if extra_configs['deseq2']['program_params'].get('contrasts'):
+               paramsD['deseq2']['program_params']['contrasts'] = {} # get rid of default contrasts
+        
+        # check main configfile
+        if configD.get('deseq2'):
+            if configD['deseq2']['program_params'].get('contrasts'):
                 paramsD['deseq2']['program_params']['contrasts'] = {} # get rid of default contrasts
 
         # first update with extra configs, then with main configfile

--- a/run_eelpond
+++ b/run_eelpond
@@ -195,6 +195,7 @@ def main(args):
             sys.exit(-1)
         # next, grab all eelpond defaults, including rule-specific default parameters (*_params.yaml files) 
         paramsD = build_default_params(thisdir, targs)
+
         # add any configuration from extra config files
         extra_configs = {}
         if args.extra_config:
@@ -202,9 +203,16 @@ def main(args):
                 extra_configs = import_configfile(find_yaml(thisdir, c, 'extra_config'), extra_configs)
         # this function only updates keys that already exist. so we need to wait till here (after importing params) to read in extra_configs,
         # rather than doing this when reading in the main configfile
+        
+        # if we're adding any additional contrasts, get rid of the example ones!
+        if extra_configs.get('deseq2') or configD.get('deseq2'):
+            if paramsD.get('deseq2'):
+                paramsD['deseq2']['program_params']['contrasts'] = {} # get rid of default contrasts
+
         # first update with extra configs, then with main configfile
         update_nested_dict(paramsD,extra_configs)
-        # update defaults with user-specified parameters
+
+        # update defaults with user-specified parameters (main configfile)
         update_nested_dict(paramsD,configD) # configD takes priority over default params 
 
         # add extension to overall assembly_extensions info


### PR DESCRIPTION
Deseq2 has a parameter that is different than nearly all others: contrasts. Contrasts must be a dictionary (containing the names of the two conditions to compare). However, since the name of each contrast is up to the user (based on their data), we're not able to properly override the default values with dictionary updates. 

This change checks if the user has added any additional contrasts, and if so, sets our default contrasts to {}. This allows us to keep the default contrast information in the `deseq2_params.yaml` file both for 1. enabling easy test data runs, and 2. providing an example of what the contrasts info should look like. 

thanks to @ACharbonneau for running into this bug